### PR TITLE
changed property "Regex.MatchResult.captures" type from String array to String optional array ([String?])

### DIFF
--- a/src/Regex.swift
+++ b/src/Regex.swift
@@ -66,12 +66,12 @@ public struct Regex
     /**
         Attempts to create a `Regex` with the provided `pattern`.  If this fails, a tuple `(nil, NSError)` is returned.  If it succeeds, a tuple `(Regex, nil)` is returned.
      */
-    public static func create(pattern:String) -> (Regex?, NSError?)
+    public static func create(pattern:String, options: NSRegularExpressionOptions = []) -> (Regex?, NSError?)
     {
         var err: NSError?
         let regex: Regex?
         do {
-            regex = try Regex(pattern: pattern)
+            regex = try Regex(pattern: pattern, options: options)
         } catch let error as NSError {
             err = error
             regex = nil
@@ -90,13 +90,13 @@ public struct Regex
 
         - parameter p: A string containing a regular expression pattern.
      */
-    public init(_ p:String)
+    public init(_ p:String, options: NSRegularExpressionOptions = [])
     {
         pattern = p
 
         let regex: NSRegularExpression?
         do {
-            regex = try NSRegularExpression(pattern: pattern, options: NSRegularExpressionOptions(rawValue: 0))
+            regex = try NSRegularExpression(pattern: pattern, options: options)
         } catch _ as NSError {
             fatalError("Invalid regex: \(p)")
         }
@@ -117,7 +117,7 @@ public struct Regex
         - parameter p: A string containing a regular expression pattern.
         - parameter error: An `NSErrorPointer` that will contain an `NSError` if initialization fails.
      */
-    public init (pattern p:String) throws
+    public init (pattern p:String, options: NSRegularExpressionOptions = []) throws
     {
         var error: NSError! = NSError(domain: "Migrator", code: 0, userInfo: nil)
         pattern = p
@@ -125,7 +125,7 @@ public struct Regex
         var err: NSError?
         let regex: NSRegularExpression?
         do {
-            regex = try NSRegularExpression(pattern: pattern, options: NSRegularExpressionOptions(rawValue: 0))
+            regex = try NSRegularExpression(pattern: pattern, options: options)
         } catch let error as NSError {
             err = error
             regex = nil

--- a/src/Regex.swift
+++ b/src/Regex.swift
@@ -31,8 +31,8 @@ extension String
     var fullRange:   Range<String.Index> { return startIndex ..< endIndex }
     var fullNSRange: NSRange             { return NSRange(location:0, length:self.characters.count) }
 
-    func substringWithRange (range:NSRange) -> String {
-       return substringWithRange(convertRange(range))
+    func substringWithRange (range:NSRange) -> String? {
+        return  convertRange(range).flatMap { substringWithRange($0) }
     }
 
     func convertRange (range: Range<Int>) -> Range<String.Index> {
@@ -41,7 +41,9 @@ extension String
         return Range(start: start, end: end)
     }
 
-    func convertRange (nsrange:NSRange) -> Range<String.Index> {
+    func convertRange (nsrange:NSRange) -> Range<String.Index>? {
+        guard nsrange.location != NSNotFound else { return nil }
+
         let start = self.startIndex.advancedBy(nsrange.location)
         let end   = start.advancedBy(nsrange.length)
         return Range(start: start, end: end)
@@ -218,7 +220,7 @@ public struct RegexMatchResult: SequenceType, BooleanType
     public let items: [NSTextCheckingResult]
 
     /** An array of the captures as `String`s.  Ordering is the same as the return value of Javascript's `String.match()` method. */
-    public let captures: [String]
+    public let captures: [String?]
 
 
     /**
@@ -254,7 +256,7 @@ public struct RegexMatchResult: SequenceType, BooleanType
     /**
         Returns the captured text of the `i`th match as a `String`.
      */
-    subscript (i: Int) -> String {
+    subscript (i: Int) -> String? {
         get { return captures[i] }
     }
 
@@ -271,7 +273,7 @@ public struct RegexMatchResult: SequenceType, BooleanType
     /**
         Returns a `Generator` that iterates over the captured matches as `String`s.
      */
-    public func generateCaptures() -> AnyGenerator<String> {
+    public func generateCaptures() -> AnyGenerator<String?> {
         var gen = captures.generate()
         return anyGenerator { gen.next() }
     }


### PR DESCRIPTION
Needed for more complex regular expressions where NSRegularExpression returns NSRange with location == NSNotFound.

Example: 
let regex = Regex("([a-z]+)(\.([a-z]+))?\.([a-z]+)")
let result = regex.match("abcd.abcd")

Expected result is ["abcd", nil, nil, "abcd"] but it throws an exception in current version

String.match() in JavaScript has the same behaviour.
